### PR TITLE
fix: correct Antigravity URL scheme and add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ _Without the extension: annoying browser prompts every time_
 | ---------------- | -------------------- | --------------- |
 | VS Code          | `vscode://`          | Official stable |
 | VS Code Insiders | `vscode-insiders://` | Preview release |
-| Antigravity      | `antigravity://`     | Antigravity IDE |
+| Antigravity      | `antigraavity://`    | Antigravity IDE |
 | Cursor           | `cursor://`          | AI-first IDE    |
 | Windsurf         | `windsurf://`        | Codeium IDE     |
 
@@ -92,7 +92,7 @@ npm run validate
 ### Method 3: VSIX Files
 
 1. Right-click on a `.vsix` download link
-2. Click "📦 Install extension with [IDE Name]"
+2. Click "📦 Install extension with \[IDE Name\]"
 3. The extension will be installed in your chosen IDE
 
 ## 🧪 Testing
@@ -105,7 +105,7 @@ Try these websites to test the extension:
 
 ## 📁 File Structure
 
-```
+```text
 ide-link-interceptor/
 ├── manifest.json    # Extension configuration
 ├── content.js       # Link interception script

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -19,7 +19,7 @@ Chrome 擴充功能，攔截 IDE 協議連結（`vscode://`、`cursor://`、`win
 | ---------------- | -------------------- |
 | VS Code          | `vscode://`          |
 | VS Code Insiders | `vscode-insiders://` |
-| Antigravity      | `antigravity://`     |
+| Antigravity      | `antigraavity://`    |
 | Cursor           | `cursor://`          |
 | Windsurf         | `windsurf://`        |
 
@@ -47,7 +47,7 @@ Chrome 擴充功能，攔截 IDE 協議連結（`vscode://`、`cursor://`、`win
 ### 方法三：安裝 VSIX 擴充套件
 
 1. 在 `.vsix` 下載連結上按右鍵
-2. 點擊「📦 用 [IDE 名稱] 安裝此擴充套件」
+2. 點擊「📦 用 \[IDE 名稱\] 安裝此擴充套件」
 3. 擴充套件會自動安裝到選定的 IDE
 
 ## 🧪 測試

--- a/background.js
+++ b/background.js
@@ -1,11 +1,11 @@
 const STORAGE_KEY = "selectedProtocol";
-const DEFAULT_PROTOCOL = "antigravity";
+const DEFAULT_PROTOCOL = "antigraavity";
 
 // IDE 選項配置
 const IDE_OPTIONS = [
   { id: "vscode", name: "VS Code", desc: "Official stable" },
   { id: "vscode-insiders", name: "VS Code Insiders", desc: "Preview release" },
-  { id: "antigravity", name: "Antigravity", desc: "Antigravity IDE" },
+  { id: "antigraavity", name: "Antigravity", desc: "Antigravity IDE" },
   { id: "cursor", name: "Cursor", desc: "AI-first IDE" },
   { id: "windsurf", name: "Windsurf", desc: "Codeium IDE" },
 ];
@@ -29,7 +29,7 @@ async function getCurrentIDEName() {
  */
 async function createContextMenus() {
   const ideName = await getCurrentIDEName();
-  
+
   // 移除所有現有選單
   chrome.contextMenus.removeAll(() => {
     // ============ VSIX 連結專用選單 ============
@@ -95,7 +95,7 @@ async function updateMenuCheckState() {
 function parseExtensionFromVsixUrl(url) {
   try {
     const urlObj = new URL(url);
-    
+
     // Open VSX 格式: /api/{namespace}/{name}/{version}/file/{filename}.vsix
     const openVsxMatch = urlObj.pathname.match(/\/api\/([^/]+)\/([^/]+)\/[^/]+\/file\//);
     if (openVsxMatch) {
@@ -104,7 +104,7 @@ function parseExtensionFromVsixUrl(url) {
         name: openVsxMatch[2]
       };
     }
-    
+
     // 嘗試從檔案名解析: {publisher}.{name}-{version}.vsix
     const filename = urlObj.pathname.split('/').pop();
     const dotMatch = filename.match(/^([^.]+)\.([^-]+)/);
@@ -114,7 +114,7 @@ function parseExtensionFromVsixUrl(url) {
         name: dotMatch[2]
       };
     }
-    
+
     return null;
   } catch {
     return null;
@@ -131,12 +131,12 @@ async function handleMenuClick(info, tab) {
   if (menuId === "install-vsix" && info.linkUrl) {
     const result = await chrome.storage.sync.get(STORAGE_KEY);
     const protocol = result[STORAGE_KEY] || DEFAULT_PROTOCOL;
-    
+
     const extInfo = parseExtensionFromVsixUrl(info.linkUrl);
     if (extInfo) {
       const protocolUrl = `${protocol}:extension/${extInfo.publisher}.${extInfo.name}`;
       console.log(`[IDE Switcher] Installing extension: ${protocolUrl}`);
-      
+
       // 在目前分頁觸發協議
       chrome.tabs.update(tab.id, { url: protocolUrl });
     } else {

--- a/content.js
+++ b/content.js
@@ -9,11 +9,11 @@
  * 2. JavaScript 動態觸發的協議導航（如 GitHub MCP）
  */
 
-(function() {
+(function () {
   'use strict';
 
   const STORAGE_KEY = 'selectedProtocol';
-  const DEFAULT_PROTOCOL = 'antigravity';
+  const DEFAULT_PROTOCOL = 'antigraavity';
 
   // 支援攔截的 IDE 協議前綴（包含競爭 IDE）
   const VSCODE_PROTOCOLS = [
@@ -23,13 +23,13 @@
     'windsurf:',
     'vscodium:'
   ];
-  
+
   // 支援攔截的 vscode.dev 重定向網址模式 (GitHub MCP 使用)
   const VSCODE_DEV_REDIRECT_PATTERNS = [
     'vscode.dev/redirect',
     'insiders.vscode.dev/redirect'
   ];
-  
+
   // 當前選擇的目標協議
   let targetProtocol = DEFAULT_PROTOCOL;
 
@@ -89,14 +89,14 @@
   function convertVSCodeDevToProtocol(url) {
     try {
       const urlObj = new URL(url);
-      
+
       // 格式 1: 檢查是否有 url 參數（GitHub MCP Registry 使用）
       const urlParam = urlObj.searchParams.get('url');
       if (urlParam) {
         // 解碼 url 參數，取得實際的 vscode: 連結
         const decodedUrl = decodeURIComponent(urlParam);
         console.log(`[IDE Switcher] 解碼的 vscode 連結: ${decodedUrl}`);
-        
+
         // 替換協議 (vscode: 或 vscode-insiders: → 目標協議)
         for (const protocol of VSCODE_PROTOCOLS) {
           if (decodedUrl.startsWith(protocol)) {
@@ -109,7 +109,7 @@
         }
         return decodedUrl;
       }
-      
+
       // 格式 2: 路徑格式 (/redirect/mcp/install?...)
       const path = urlObj.pathname.replace('/redirect', '');
       const queryString = urlObj.search;
@@ -143,22 +143,22 @@
     if (!link) return;
 
     const href = link.getAttribute('href') || link.href;
-    
+
     // 處理 vscode.dev 重定向連結 (GitHub MCP 使用)
     if (isVSCodeDevRedirectUrl(href)) {
       const targetUrl = convertVSCodeDevToProtocol(href);
       if (!targetUrl) return;
-      
+
       event.preventDefault();
       event.stopPropagation();
-      
+
       console.log(`[IDE Switcher] 攔截 vscode.dev 連結: ${href}`);
       console.log(`[IDE Switcher] 重定向至: ${targetUrl}`);
-      
+
       window.location.href = targetUrl;
       return;
     }
-    
+
     // 處理標準 vscode:// 協議連結
     if (!isVSCodeUrl(href)) return;
 
@@ -194,7 +194,7 @@
     script.textContent = `
       (function() {
         const TARGET_PROTOCOL = '${targetProtocol}';
-        const VSCODE_PROTOCOLS = ['vscode:', 'vscode-insiders:', 'cursor:', 'windsurf:', 'vscodium:'];
+        const VSCODE_PROTOCOLS = ['vscode:', 'vscode-insiders:', 'cursor:', 'windsurf:', 'vscodium:', 'antigraavity:'];
         const VSCODE_DEV_PATTERNS = ['vscode.dev/redirect', 'insiders.vscode.dev/redirect'];
         
         // 檢查是否為 VS Code 協議 URL
@@ -334,7 +334,7 @@
         console.log('[IDE Switcher] JS 攔截器已注入，目標: ' + TARGET_PROTOCOL);
       })();
     `;
-    
+
     // 盡早注入腳本
     (document.head || document.documentElement).appendChild(script);
   }
@@ -348,9 +348,9 @@
         if (mutation.type === 'childList') {
           mutation.addedNodes.forEach((node) => {
             if (node.nodeType === Node.ELEMENT_NODE) {
-              const links = node.querySelectorAll ? 
+              const links = node.querySelectorAll ?
                 node.querySelectorAll('a[href^="vscode:"], a[href^="vscode-insiders:"], a[href^="cursor:"], a[href^="windsurf:"], a[href^="vscodium:"]') : [];
-              
+
               links.forEach(link => {
                 if (!link.dataset.ideSwitcherProcessed) {
                   link.dataset.ideSwitcherProcessed = 'true';
@@ -374,10 +374,10 @@
   async function init() {
     await loadSettings();
     listenForSettingsChanges();
-    
+
     // 注入 JS 攔截器（攔截動態導航）
     injectInterceptorScript();
-    
+
     // 監聯連結點擊（攔截標準 <a> 連結）
     document.addEventListener('click', handleClick, true);
 

--- a/docs/url-conversion-rules.md
+++ b/docs/url-conversion-rules.md
@@ -1,0 +1,148 @@
+# 網址轉換規則說明
+
+以下文件說明如何將標準 HTTP(S) 的 GitHub 或 Open VSX 連結轉換為各編輯器可識別的自訂協議 URI，包含範本、欄位說明、實作步驟、範例以及安全注意事項。範例以 `https://github.com/mcp/upstash/context7` 為來源示範。
+
+---
+
+## 概要
+
+- **目的**：把一般的網頁連結轉成各編輯器自訂協議 URI，方便直接從瀏覽器啟動編輯器並開啟遠端 repo 或安裝 VSIX。
+- **支援編輯器**：VS Code stable, VS Code Insiders, Antigravity, Cursor, Windsurf Codeium。
+- **兩類場景**：打開遠端 repo 或檔案；安裝 `.vsix` 擴充套件（例如來自 Open VSX 的檔案）。
+
+---
+
+## 通用模板與欄位說明
+
+**通用模板**
+
+```
+{editor}://{provider}/{action}?url={URL_ENCODED_TARGET}&branch={branch}&path={subdir}&file={file}&line={line}&name={publisher.extension}&version={version}
+```
+
+**欄位說明**
+
+- **editor**：編輯器協議名稱，例如 `vscode`、`vscode-insiders`、`antigraavity`、`cursor`、`windsurf`。
+- **provider**：編輯器內處理遠端資源的模組或命名空間，例如 `github.remotehub`、`repo`、`git`、`extension`。
+- **action**：動作，例如 `open`、`install`、`clone`、`browse`。
+- **url**：目標資源的完整 URL，**必須 URL encode**。
+- **branch**：可選，指定分支名稱。
+- **path**：可選，指定子目錄。
+- **file**：可選，指定檔案相對路徑。
+- **line**：可選，指定行號。
+- **name**：安裝 VSIX 時的擴充識別名稱，例如 `publisher.extension`。
+- **version**：安裝 VSIX 時的版本號。
+
+---
+
+## 編輯器協議範例表
+
+| **Editor** | **Scheme** | **用途** | **範例打開 Repo** | **範例安裝 VSIX** |
+|---|---:|---|---|---|
+| VS Code stable | `vscode://` | 官方穩定版 | `vscode://github.remotehub/open?url=https%3A%2F%2Fgithub.com%2Fmcp%2Fupstash%2Fcontext7` | `vscode://extension/install?url=https%3A%2F%2Fopen-vsx.org%2Fapi%2Fpub%2Fext%2F1.2.3%2Ffile&name=pub.ext&version=1.2.3` |
+| VS Code Insiders | `vscode-insiders://` | 預覽版 | `vscode-insiders://github.remotehub/open?url=...` | `vscode-insiders://extension/install?url=...` |
+| Antigravity IDE | `antigraavity://` | Antigravity 自訂協議 | `antigraavity://git/open?url=https%3A%2F%2Fgithub.com%2Fmcp%2Fupstash%2Fcontext7` | `antigraavity://extension/install?url={VSIX_URL}&name={publisher.ext}` |
+| Cursor AI IDE | `cursor://` | AI first IDE | `cursor://repo/open?url=https%3A%2F%2Fgithub.com%2Fmcp%2Fupstash%2Fcontext7` | `cursor://extension/install?url={VSIX_URL}&name={publisher.ext}` |
+| Windsurf Codeium | `windsurf://` | Codeium IDE | `windsurf://repo/open?url=https%3A%2F%2Fgithub.com%2Fmcp%2Fupstash%2Fcontext7` | `windsurf://extension/install?url={VSIX_URL}&name={publisher.ext}` |
+
+---
+
+## 轉換與編碼步驟
+
+1. **取得原始 URL**
+   例如：`https://github.com/mcp/upstash/context7` 或 Open VSX 的 VSIX 下載連結 `https://open-vsx.org/api/pub/ext/1.2.3/file`。
+
+2. **URL encode 目標 URL**
+   - 將 `:` `/` `?` `&` 等字元轉為百分比編碼。
+   - 範例編碼結果：
+
+     ```
+     https%3A%2F%2Fgithub.com%2Fmcp%2Fupstash%2Fcontext7
+     ```
+
+3. **選擇 editor 與 provider 並套入模板**
+   - 例如要在 Antigravity 打開 repo：
+
+     ```
+     antigraavity://git/open?url=https%3A%2F%2Fgithub.com%2Fmcp%2Fupstash%2Fcontext7
+     ```
+
+4. **加入可選參數**
+   - 指定分支：`&branch=main`
+   - 指定子目錄：`&path=context7`
+   - 指定檔案與行號：`&file=src%2Findex.js&line=42`
+
+5. **測試**
+   - 在支援該協議的系統上點擊或在瀏覽器地址列貼上 URI，確認編輯器被喚起並執行預期動作。
+
+---
+
+## Open VSX 與 VSIX 安裝範例
+
+- **Open VSX 直接檔案 URL 常見格式**
+
+  ```
+  https://open-vsx.org/api/{publisher}/{extension}/{version}/file
+  ```
+
+- **將 VSIX URL 套入安裝模板**
+  - Antigravity 安裝範例（已編碼）
+
+    ```
+    antigraavity://extension/install?url=https%3A%2F%2Fopen-vsx.org%2Fapi%2Fpub%2Fext%2F1.2.3%2Ffile&name=pub.ext&version=1.2.3
+    ```
+
+- **若編輯器不支援協議**
+  - 使用 CLI 或內建功能安裝 VSIX，例如 VS Code CLI：
+
+    ```
+    code --install-extension path_or_url_to_vsix
+    ```
+
+  - 或先下載 VSIX 檔案再透過編輯器的「Install from VSIX」功能安裝。
+
+---
+
+## 安全與實務注意事項
+
+- **務必 URL encode** 所有作為查詢參數的完整 URL。
+- **不要在 URI 中放入敏感資訊**，例如 access token、密碼或私人憑證。
+- **授權需求**：若資源需要授權，請使用編輯器或平台提供的 OAuth 或授權流程，不要把 token 放在 URI。
+- **協議註冊**：系統必須已註冊該自訂協議並綁定到對應應用程式，否則瀏覽器會顯示錯誤或無回應。
+- **擴充相容性**：不同編輯器可能使用不同 provider 或 action 命名，請參考該編輯器官方文件或擴充說明以取得正確格式。
+- **防範惡意 URL**：只對可信來源使用自訂協議，避免被惡意 URL 利用來執行不預期動作。
+
+---
+
+## 常見問題與對策
+
+- **Q 編輯器沒有反應**
+  - A 檢查系統是否註冊該協議，或改用 CLI/手動安裝。
+
+- **Q URL 包含特殊字元導致失敗**
+  - A 確認完整 URL 已正確 URL encode。
+
+- **Q 需要指定分支或檔案但編輯器不支援**
+  - A 改為先 clone 到本地再用編輯器開啟，或使用該編輯器的遠端擴充功能。
+
+---
+
+## 實用範例總結
+
+- **打開 GitHub repo 在 Antigravity**
+
+  ```
+  antigraavity://git/open?url=https%3A%2F%2Fgithub.com%2Fmcp%2Fupstash%2Fcontext7
+  ```
+
+- **在 Cursor 打開 repo 並指定分支與子目錄**
+
+  ```
+  cursor://repo/open?url=https%3A%2F%2Fgithub.com%2Fmcp%2Fupstash%2Fcontext7&branch=main&path=context7
+  ```
+
+- **在 Antigravity 安裝來自 Open VSX 的 VSIX**
+
+  ```
+  antigraavity://extension/install?url=https%3A%2F%2Fopen-vsx.org%2Fapi%2Fpub%2Fext%2F1.2.3%2Ffile&name=pub.ext&version=1.2.3
+  ```


### PR DESCRIPTION
This PR corrects the Antigravity URL scheme from 'antigravity://' to 'antigraavity://' and adds comprehensive URL conversion documentation.